### PR TITLE
add w/o double pointer for recursive

### DIFF
--- a/Linked_List/Q7_A_LL.c
+++ b/Linked_List/Q7_A_LL.c
@@ -85,13 +85,31 @@ int main()
 
 ////////////////////////////////////////////////////////////////////////
 
+// void RecursiveReverse(ListNode *ptrHead) {
+// 	ListNode *first, *rest;
+// 	first = ptrHead;
+// 	rest = ptrHead;
+
+// 	if (rest == NULL || rest->next == NULL)
+// 		return;
+
+// 	rest = rest->next;
+
+// 	RecursiveReverse(rest);
+
+// 	printf("First: %d, Rest: %d\n", first->item, rest->item);
+// 	first->next->next = first;
+// 	first->next = NULL;
+// 	ptrHead = rest;
+// }
+
 void RecursiveReverse(ListNode **ptrHead)
 {
 	ListNode *first, *rest;
 	first = *ptrHead;
 	rest = *ptrHead;
 
-	if (rest == NULL || rest->next == NULL)
+	if (rest->next == NULL)
 		return;
 	
 	rest = rest->next;


### PR DESCRIPTION
이중포인터를 사용하는 이유
- 포인터 한 개로 헤드를 넘겨주면 주소 참조가 아닌 값만 복사됨
- `call by reference` 를 위해 이중 포인터 사용