### PR TITLE
bst q2 fix

### DIFF
--- a/Binary_Search_Tree/Q2_F_BST.c
+++ b/Binary_Search_Tree/Q2_F_BST.c
@@ -95,22 +95,20 @@ void inOrderTraversal(BSTNode *root)
 	s.top = NULL;
 
 	BSTNode *cur = root;
-	push(&s, cur);
-
-	while (!isEmpty(&s)) {
-		while (cur->left != NULL) {
-			push(&s, cur->left);
+	do {
+		// 	왼쪽 자식을 모두 푸쉬
+		while (cur != NULL) {
+			push(&s, cur);
 			cur = cur->left;
 		}
 
-		BSTNode *top = pop(&s);
-		printf("%d ", top->item);
+		// 더이상 없으면 pop
+		cur = pop(&s);
+		printf("%d ", cur->item);
 
-		while (top->right != NULL) {
-			push(&s, top->right);
-			top = top->right;
-		}
-	}
+		// 오른쪽 자식으로 이동해 반복
+		cur = cur->right;
+	} while (cur != NULL || !isEmpty(&s));
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<img width="932" alt="image" src="https://github.com/yunnn426/Data-Structures/assets/95147113/4123fba5-92dc-411e-bb66-db199763f4b3">

기존에 푼 q2는 오른쪽 자식에게 왼쪽 자식노드가 있는 경우 출력되지 않는 문제가 있음
ex. 
![image](https://github.com/yunnn426/Data-Structures/assets/95147113/dd035ca8-81f3-40e7-b38b-9bb9c5934718)

> 5 10 15 18 20 30 
- 12 출력 안됨

